### PR TITLE
fix warning on amount and original  amount

### DIFF
--- a/DatabaseManager/AppDbContext.cs
+++ b/DatabaseManager/AppDbContext.cs
@@ -25,6 +25,8 @@ namespace DatabaseManager
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<DailyTransaction>().HasKey(d => d.Content);
+            modelBuilder.Entity<DailyTransaction>(entity => { entity.Property(p => p.Amount).HasColumnType("decimal(15, 2)"); });
+            modelBuilder.Entity<DailyTransaction>(entity => { entity.Property(p => p.Original_Amount).HasColumnType("decimal(15, 2)"); });
             modelBuilder.Entity<KeywordToCostCategory>().HasNoKey();
             modelBuilder.Entity<KeywordToSavingsCategory>().HasNoKey();
         }


### PR DESCRIPTION
there an ILogger warning taking place because the data type on Amount and Original_Amount columns was not set correctly. This could cause a truncation in values.